### PR TITLE
Update go backend client

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -2,12 +2,16 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Copy the HTML client files
-COPY simple_client.html .
-COPY serve_client.py .
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy client files
+COPY client.html .
+COPY client.py .
 
 # Expose HTTP server port
 EXPOSE 8080
 
-# Run simple HTTP server
-CMD ["python3", "serve_client.py"]
+# Run the client in web server mode
+CMD ["python3", "client.py", "--mode", "server", "--port", "8080"]

--- a/client/client.html
+++ b/client/client.html
@@ -466,13 +466,13 @@
             
             switch (protocol) {
                 case 'websocket':
-                    endpoint = 'ws://localhost:8000/ws/medical/direct';
+                    endpoint = 'ws://localhost:8000/ws';
                     break;
                 case 'http2':
-                    endpoint = 'ws://localhost:8000/ws/medical/http2';
+                    endpoint = 'ws://localhost:8000/ws';
                     break;
                 case 'unified':
-                    endpoint = 'ws://localhost:8000/ws/medical/unified';
+                    endpoint = 'ws://localhost:8000/ws';
                     break;
             }
             

--- a/client/client.py
+++ b/client/client.py
@@ -38,9 +38,15 @@ logger = logging.getLogger(__name__)
 class MedicalStreamingClient:
     """Client for real-time medical transcription via WebSocket."""
     
-    def __init__(self, websocket_url: str = "ws://localhost:8000/ws/medical"):
+    def __init__(self, websocket_url: str = None):
         if not AUDIO_LIBS_AVAILABLE:
             raise ImportError("Required audio libraries not available. Install with: pip install pyaudio websockets numpy")
+        
+        # Use environment variable or default
+        if websocket_url is None:
+            backend_host = os.environ.get('BACKEND_HOST', 'localhost')
+            backend_port = os.environ.get('BACKEND_PORT', '8000')
+            websocket_url = f"ws://{backend_host}:{backend_port}/ws"
             
         self.websocket_url = websocket_url
         self.websocket = None
@@ -303,7 +309,7 @@ async def run_python_client(url: str = None):
         print("Install with: pip install pyaudio websockets numpy")
         return
         
-    client = MedicalStreamingClient(url or "ws://localhost:8000/ws/medical")
+    client = MedicalStreamingClient(url or "ws://localhost:8000/ws")
     await client.run_interactive()
 
 
@@ -326,7 +332,7 @@ def main():
     )
     parser.add_argument(
         '--url',
-        default='ws://localhost:8000/ws/medical',
+        default='ws://localhost:8000/ws',
         help='WebSocket URL for Python client'
     )
     


### PR DESCRIPTION
Update client to connect to the Go backend's `/ws` endpoint and improve Docker build/runtime configuration.

The previous client configuration was hardcoded to `/ws/medical` which is not exposed by the Go backend. This PR updates the WebSocket endpoint in both Python and HTML clients, fixes the Dockerfile to correctly build and run the client, and adds environment variable support for the backend host/port to facilitate Docker deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-20074631-16c5-4a3e-8893-a46eccc6e659">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20074631-16c5-4a3e-8893-a46eccc6e659">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

